### PR TITLE
Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^7.1.3",
-        "illuminate/support": "^5.6",
+        "illuminate/support": "^5.6|^6",
         "league/oauth2-instagram": "^2.0"
     },
     "require-dev": {

--- a/src/Facades/Instagram.php
+++ b/src/Facades/Instagram.php
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  *
  * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
- * @license http://opensource.org/licenses/MIT MIT
+ * @license   http://opensource.org/licenses/MIT MIT
  */
 
 declare(strict_types=1);

--- a/src/Facades/Instagram.php
+++ b/src/Facades/Instagram.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the ramsey/laravel-oauth2-instagram library
  *

--- a/src/InstagramServiceProvider.php
+++ b/src/InstagramServiceProvider.php
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  *
  * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
- * @license http://opensource.org/licenses/MIT MIT
+ * @license   http://opensource.org/licenses/MIT MIT
  */
 
 declare(strict_types=1);
@@ -36,9 +36,11 @@ class InstagramServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $this->publishes([
+        $this->publishes(
+            [
             __DIR__ . '/config/instagram.php' => config_path('instagram.php'),
-        ]);
+            ]
+        );
     }
 
     /**
@@ -48,13 +50,17 @@ class InstagramServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->bind(LeagueInstagram::class, function ($app) {
-            return new LeagueInstagram([
-                'clientId' => config('instagram.clientId'),
-                'clientSecret' => config('instagram.clientSecret'),
-                'redirectUri' => config('instagram.redirectUri'),
-            ]);
-        });
+        $this->app->bind(
+            LeagueInstagram::class, function ($app) {
+                return new LeagueInstagram(
+                    [
+                    'clientId' => config('instagram.clientId'),
+                    'clientSecret' => config('instagram.clientSecret'),
+                    'redirectUri' => config('instagram.redirectUri'),
+                    ]
+                );
+            }
+        );
     }
 
     /**

--- a/src/InstagramServiceProvider.php
+++ b/src/InstagramServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the ramsey/laravel-oauth2-instagram library
  *
@@ -51,7 +52,8 @@ class InstagramServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(
-            LeagueInstagram::class, function ($app) {
+            LeagueInstagram::class,
+            function ($app) {
                 return new LeagueInstagram(
                     [
                     'clientId' => config('instagram.clientId'),

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Ramsey\Laravel\OAuth2\Instagram\Test;

--- a/tests/Facades/InstagramFacadeTest.php
+++ b/tests/Facades/InstagramFacadeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Ramsey\Laravel\OAuth2\Instagram\Test\Facades;

--- a/tests/InstagramServiceProviderTest.php
+++ b/tests/InstagramServiceProviderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Ramsey\Laravel\OAuth2\Instagram\Test;

--- a/tests/InstagramTestCase.php
+++ b/tests/InstagramTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Ramsey\Laravel\OAuth2\Instagram\Test;


### PR DESCRIPTION
The plugin was locked into an old version of illuminate/support in the dependencies.

## Description
Updated composer

## Motivation and Context
To use Laravel 6

## How Has This Been Tested?
Honestly, I haven't. I just looked at the diff. https://github.com/illuminate/support/compare/5.8...6.x

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have run `composer run test` locally, and there were no failures or errors.
